### PR TITLE
Update to WSI Swapchain chapter regarding "release" and "present" terminology

### DIFF
--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -45,7 +45,7 @@ The presentable images of a swapchain are owned by the presentation engine.
 An application can: acquire use of a presentable image from the presentation
 engine.
 Use of a presentable image must: occur only after the image is returned by
-fname:vkAcquireNextImageKHR, and before it is presented by
+fname:vkAcquireNextImageKHR, and before it is released by
 fname:vkQueuePresentKHR.
 This includes transitioning the image layout and rendering commands.
 
@@ -870,13 +870,7 @@ If pname:timeout is code:UINT64_MAX, the timeout period is treated as
 infinite, and fname:vkAcquireNextImageKHR will block until an image is
 acquired or an error occurs.
 
-An image will eventually be acquired if the number of images that the
-application has currently acquired (but not yet presented) is less than or
-equal to the difference between the number of images in pname:swapchain and
-the value of slink:VkSurfaceCapabilitiesKHR::pname:minImageCount.
-If the number of currently acquired images is greater than this,
-fname:vkAcquireNextImageKHR should: not be called; if it is, pname:timeout
-must: not be code:UINT64_MAX.
+fname:vkAcquireNextImageKHR should: not be called if the number of images that the application has currently acquired is greater than the difference between the number of images in pname:swapchain and the value of slink:VkSurfaceCapabilitiesKHR::pname:minImageCount.
 
 If an image is acquired successfully, fname:vkAcquireNextImageKHR must:
 either return ename:VK_SUCCESS, or ename:VK_SUBOPTIMAL_KHR if the swapchain

--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -870,7 +870,10 @@ If pname:timeout is code:UINT64_MAX, the timeout period is treated as
 infinite, and fname:vkAcquireNextImageKHR will block until an image is
 acquired or an error occurs.
 
-fname:vkAcquireNextImageKHR should: not be called if the number of images that the application has currently acquired is greater than the difference between the number of images in pname:swapchain and the value of slink:VkSurfaceCapabilitiesKHR::pname:minImageCount.
+fname:vkAcquireNextImageKHR should: not be called if the number of images
+that the application has currently acquired is greater than the difference
+between the number of images in pname:swapchain and the value of
+slink:VkSurfaceCapabilitiesKHR::pname:minImageCount.
 
 If an image is acquired successfully, fname:vkAcquireNextImageKHR must:
 either return ename:VK_SUCCESS, or ename:VK_SUBOPTIMAL_KHR if the swapchain


### PR DESCRIPTION
This pull request aims to resolve #1419 by updating the WSI Swapchain section's terminology (primarily replacing certain usages of the word "present" with "release" with respect to fname:vkQueuePresentKHR). This description provides a necessary and sufficient justification and discussion. See the linked issue for further details if desired.

This PR updates a paragraph in the WSI Swapchain section of the docs. It also replaces one other use of the term "present" with "release".

The previous wording of the paragraph:

> An image will eventually be acquired if the number of images that the
> application has currently acquired (but not yet presented) is less than or
> equal to the difference between the number of images in pname:swapchain and
> the value of slink:VkSurfaceCapabilitiesKHR::pname:minImageCount.
> If the number of currently acquired images is greater than this,
> fname:vkAcquireNextImageKHR should: not be called; if it is, pname:timeout
> must: not be code:UINT64_MAX.

Problems:

"An image will eventually be acquired..." is not necessarily true. It is only true if pname:timeout is UINT64_MAX. Otherwise, a timeout may occur (0 < pname:timeout < UINT64_MAX) or an image may not be available (pname:timeout = 0). This paragraph follows another paragraph relating to UINT64_MAX timeouts, but such a timeout is _not_ implied by this paragraph. Moreover, most of this is redundant, including the "must not" portion at the end of the paragraph, because it's just a reiteration of the function's [valid usage](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-vkAcquireNextImageKHR-swapchain-01802), which is the more appropriate place for the information to reside _anyways_.

The only part of the paragraph which adds new, helpful information is the "should not" portion (i.e., you should not call the function at all if you've acquired all of the available swapchain images). Thus, here is the proposed rewrite:

> fname:vkAcquireNextImageKHR should: not be called if the number of images that the application has currently acquired is greater than the difference between the number of images in pname:swapchain and the value of slink:VkSurfaceCapabilitiesKHR::pname:minImageCount.

Justification:

This rewrite removes redundant information and also removes the parenthetical which used the word "presented" where "released" would have been more appropriate. Particularly, the use of the term "presented" here is essentially deprecated; there was once ambiguity between an image being "presented" (i.e. by the presentation engine) and "released" (from acquisition, i.e. by the application via fname:vkQueuePresentKHR). Previously, the term "presented" was used to convey both meanings. This was found to be confusing, and so the latter usage of the term was replaced with the term "released". In this particular case, neither of the "presented" nor "released" terms are necessary, since it is implied that an image which is currently acquired is also not yet released.

Lastly, there is the sentence, "Use of a presentable image must occur only after the image is returned by fname:vkAcquireNextImageKHR, and before it is presented by fname:vkQueuePresentKHR". This is another dangling reference to the old "presented" terminology, and so it, too, should be replaced with the term, "released". This PR does this as well.